### PR TITLE
NAS-135492 / 25.10 / Add verification summary to stdout with 'syslog' option.

### DIFF
--- a/truenas_verify/mtree_verify.py
+++ b/truenas_verify/mtree_verify.py
@@ -170,6 +170,8 @@ def do_verify(args: list):
                 syslog.syslog(entry)
         finally:
             syslog.closelog()
+            # Output a message for middleware alert
+            print(msg)
     else:
         # Log headline results to console and details to LOG_PATH
         with open(log_path, 'w') as f:


### PR DESCRIPTION
Add verification summary to stdout.
This is used by middleware to craft a better alert message.

NOTE: This PR should be merged in conjunction with the same named middleware PR.